### PR TITLE
fix: add --ignore-scripts to Docker pnpm install to avoid git dependency

### DIFF
--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -10,7 +10,7 @@ COPY package.json pnpm-lock.yaml pnpm-workspace.yaml turbo.json ./
 COPY packages/ packages/
 COPY apps/ apps/
 
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 RUN pnpm turbo db:generate
 RUN pnpm turbo build --filter=@redgest/mcp-server...
 


### PR DESCRIPTION
Closes #41

The `prepare` script configures git hooks, which requires git — unavailable in the `node:20-slim` base image. Hooks are irrelevant in container builds, so `--ignore-scripts` is the clean fix.

Generated with [Claude Code](https://claude.ai/code)