### PR TITLE
fix: expand stopword list to filter common English words from trending topics

### DIFF
--- a/packages/core/src/__tests__/topic-step.test.ts
+++ b/packages/core/src/__tests__/topic-step.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { extractTopicNames, STOP_WORDS } from "../pipeline/topic-step.js";
+import type { PostSummary } from "../pipeline/types.js";
+
+function makeSummary(overrides: Partial<PostSummary> = {}): PostSummary {
+  return {
+    summary: "",
+    keyTakeaways: [],
+    insightNotes: "",
+    communityConsensus: null,
+    commentHighlights: [],
+    sentiment: "neutral",
+    relevanceScore: 0.5,
+    contentType: "text",
+    notableLinks: [],
+    ...overrides,
+  };
+}
+
+describe("STOP_WORDS", () => {
+  it("contains common English stopwords reported in issue #39", () => {
+    for (const word of ["the", "and", "for", "are", "was", "not", "but"]) {
+      expect(STOP_WORDS.has(word), `missing stopword: "${word}"`).toBe(true);
+    }
+  });
+
+  it("contains at least 100 entries", () => {
+    expect(STOP_WORDS.size).toBeGreaterThanOrEqual(100);
+  });
+
+  it("does not contain meaningful technical terms", () => {
+    for (const word of ["model", "local", "coding", "inference", "quantization"]) {
+      expect(STOP_WORDS.has(word), `should not block: "${word}"`).toBe(false);
+    }
+  });
+});
+
+describe("extractTopicNames", () => {
+  it("filters out stopwords from results", () => {
+    const summary = makeSummary({
+      summary:
+        "The model uses local inference for quantization and the approach was very effective",
+      keyTakeaways: ["The local model runs fast"],
+      insightNotes: "For the community this was a breakthrough",
+    });
+
+    const topics = extractTopicNames(summary);
+
+    // Should NOT include stopwords
+    for (const stopword of ["the", "and", "for", "was", "very", "this"]) {
+      expect(topics).not.toContain(stopword);
+    }
+
+    // Should include meaningful terms
+    expect(topics).toContain("model");
+    expect(topics).toContain("local");
+  });
+
+  it("returns up to 5 topics", () => {
+    const summary = makeSummary({
+      summary:
+        "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima",
+    });
+
+    const topics = extractTopicNames(summary);
+    expect(topics.length).toBeLessThanOrEqual(5);
+  });
+
+  it("ranks by frequency descending", () => {
+    const summary = makeSummary({
+      summary: "inference inference inference model model quantization",
+      keyTakeaways: ["inference model"],
+      insightNotes: "inference",
+    });
+
+    const topics = extractTopicNames(summary);
+    expect(topics[0]).toBe("inference");
+    expect(topics[1]).toBe("model");
+  });
+
+  it("returns empty array when only stopwords are present", () => {
+    const summary = makeSummary({
+      summary: "the and for are was not but has had can",
+      keyTakeaways: ["they were being very much"],
+      insightNotes: "this that with from have been",
+    });
+
+    const topics = extractTopicNames(summary);
+    expect(topics).toEqual([]);
+  });
+
+  it("filters words with 2 or fewer characters", () => {
+    const summary = makeSummary({
+      summary: "AI is ok to do it on an up",
+    });
+
+    const topics = extractTopicNames(summary);
+    for (const topic of topics) {
+      expect(topic.length).toBeGreaterThan(2);
+    }
+  });
+
+  it("lowercases all topics", () => {
+    const summary = makeSummary({
+      summary: "Python RUST TypeScript",
+    });
+
+    const topics = extractTopicNames(summary);
+    for (const topic of topics) {
+      expect(topic).toBe(topic.toLowerCase());
+    }
+  });
+
+  it("strips punctuation before matching", () => {
+    const summary = makeSummary({
+      summary: "model, model! model? inference... quantization;",
+    });
+
+    const topics = extractTopicNames(summary);
+    expect(topics[0]).toBe("model");
+    expect(topics).toContain("inference");
+    expect(topics).toContain("quantization");
+  });
+});

--- a/packages/core/src/pipeline/index.ts
+++ b/packages/core/src/pipeline/index.ts
@@ -21,7 +21,7 @@ export { fetchStep } from "./fetch-step.js";
 export { triageStep } from "./triage-step.js";
 export { summarizeStep } from "./summarize-step.js";
 export { assembleStep, renderDigestMarkdown } from "./assemble-step.js";
-export { topicStep } from "./topic-step.js";
+export { topicStep, extractTopicNames, STOP_WORDS } from "./topic-step.js";
 
 // Utilities
 export {

--- a/packages/core/src/pipeline/topic-step.ts
+++ b/packages/core/src/pipeline/topic-step.ts
@@ -1,56 +1,38 @@
 import type { PrismaClient } from "@redgest/db";
 import type { PostSummary } from "./types.js";
 
-const STOP_WORDS = new Set([
-  "this",
-  "that",
-  "with",
-  "from",
-  "have",
-  "been",
-  "were",
-  "they",
-  "their",
-  "about",
-  "would",
-  "could",
-  "should",
-  "which",
-  "there",
-  "these",
-  "those",
-  "what",
-  "when",
-  "where",
-  "while",
-  "also",
-  "into",
-  "more",
-  "than",
-  "then",
-  "them",
-  "some",
-  "such",
-  "very",
-  "just",
-  "will",
-  "each",
-  "make",
-  "like",
-  "does",
-  "most",
-  "many",
-  "much",
-  "other",
-  "over",
-  "only",
-  "after",
-  "before",
-  "between",
-  "being",
-  "both",
-  "same",
-  "your",
+/** ~120 common English stopwords — filtered before frequency ranking. */
+export const STOP_WORDS = new Set([
+  // Articles & conjunctions
+  "the", "and", "but", "nor", "yet", "for", "not",
+  // Pronouns
+  "you", "your", "yours", "his", "her", "hers", "its",
+  "they", "them", "their", "theirs", "she", "him", "who",
+  "whom", "whose", "this", "that", "these", "those",
+  // Prepositions
+  "with", "from", "into", "about", "over", "after", "before",
+  "between", "under", "above", "below", "through", "during",
+  "without", "against", "within", "along", "among",
+  // Be-verbs & auxiliaries
+  "are", "was", "were", "been", "being", "have", "has", "had",
+  "does", "did", "will", "would", "could", "should", "shall",
+  "might", "must", "can", "may",
+  // Common adverbs & adjectives
+  "also", "more", "than", "then", "very", "just", "most",
+  "many", "much", "only", "even", "still", "already", "often",
+  "never", "always", "really", "well", "here", "there", "where",
+  "when", "what", "which", "while", "how", "why",
+  // Common verbs (generic)
+  "each", "make", "like", "some", "such", "other", "same",
+  "both", "few", "all", "any", "own", "too", "now", "new",
+  "way", "use", "get", "got", "let", "say", "two", "one",
+  "per", "via",
+  // Longer common words
+  "because", "however", "another", "every", "something",
+  "anything", "everything", "nothing", "someone", "anyone",
+  "everyone", "using", "used", "want", "need", "come",
+  "take", "know", "think", "look", "find", "give", "tell",
+  "said", "good", "back", "down",
 ]);
 
 /**
@@ -58,7 +40,7 @@ const STOP_WORDS = new Set([
  * Returns up to 5 topic names derived from summary text and key takeaways.
  * Phase 3 baseline — can be upgraded to LLM-based extraction later.
  */
-function extractTopicNames(summary: PostSummary): string[] {
+export function extractTopicNames(summary: PostSummary): string[] {
   const text = [summary.summary, ...summary.keyTakeaways, summary.insightNotes]
     .join(" ");
 


### PR DESCRIPTION
Closes #39

## Summary

Expanded the STOP_WORDS set in topic-step.ts from ~50 to ~120 entries, adding missing common English stopwords ("the", "and", "for", etc.) that were dominating trending topic results.

## Changes

- Expanded stopword list organized by category (articles, pronouns, prepositions, auxiliaries, etc.)
- Exported extractTopicNames and STOP_WORDS for unit testing
- Added 9 unit tests for topic extraction logic

Generated with [Claude Code](https://claude.ai/code)