### PR TITLE
feat: parallelize post summarization with bounded concurrency

### DIFF
--- a/packages/core/src/__tests__/orchestrator.test.ts
+++ b/packages/core/src/__tests__/orchestrator.test.ts
@@ -701,6 +701,153 @@ describe("error recovery - unhandled exceptions (issue #3)", () => {
   });
 });
 
+describe("concurrent summarization", () => {
+  it("summarizes multiple posts concurrently and preserves order", async () => {
+    const fetchResult = makeFetchResult("typescript");
+    const basePost = fetchResult.posts[0];
+    expect(basePost).toBeDefined();
+
+    // Add 4 more posts (5 total — exceeds default concurrency of 3)
+    for (let i = 2; i <= 5; i++) {
+      fetchResult.posts.push({
+        postId: `post-${i}`,
+        redditId: `reddit-${i}`,
+        post: {
+          ...basePost?.post,
+          id: `reddit-${i}`,
+          name: `t3_reddit${i}`,
+          subreddit: "typescript",
+          title: `Test Post ${i}`,
+          selftext: `Body ${i}`,
+          author: "testuser",
+          score: 100 - i,
+          num_comments: 10,
+          url: `https://reddit.com/r/test/${i}`,
+          permalink: `/r/test/${i}`,
+          link_flair_text: null,
+          over_18: false,
+          created_utc: 1700000000 + i,
+          is_self: true,
+        },
+        comments: [],
+      });
+    }
+    mockFetchStep.mockResolvedValue(fetchResult);
+
+    mockTriageStep.mockResolvedValue({
+      selected: [
+        { index: 0, relevanceScore: 9, rationale: "R1" },
+        { index: 1, relevanceScore: 8, rationale: "R2" },
+        { index: 2, relevanceScore: 7, rationale: "R3" },
+        { index: 3, relevanceScore: 6, rationale: "R4" },
+        { index: 4, relevanceScore: 5, rationale: "R5" },
+      ],
+    });
+
+    // Each call returns a distinct summary
+    for (let i = 0; i < 5; i++) {
+      mockSummarizeStep.mockResolvedValueOnce({
+        postSummaryId: `ps-${i + 1}`,
+        summary: makeSummary({ summary: `Summary ${i + 1}` }),
+      });
+    }
+
+    const result = await runDigestPipeline("job-1", [], deps);
+
+    expect(result.status).toBe("COMPLETED");
+    const posts = result.subredditResults[0]?.posts;
+    expect(posts).toBeDefined();
+    expect(posts).toHaveLength(5);
+
+    // Verify order is preserved (results appear in original triage order)
+    expect(posts?.[0]?.redditId).toBe("reddit-1");
+    expect(posts?.[1]?.redditId).toBe("reddit-2");
+    expect(posts?.[2]?.redditId).toBe("reddit-3");
+    expect(posts?.[3]?.redditId).toBe("reddit-4");
+    expect(posts?.[4]?.redditId).toBe("reddit-5");
+
+    // All 5 summarizations were called
+    expect(mockSummarizeStep).toHaveBeenCalledTimes(5);
+  });
+
+  it("handles mixed successes and failures across concurrent posts", async () => {
+    const fetchResult = makeFetchResult("typescript");
+    const basePost = fetchResult.posts[0];
+    expect(basePost).toBeDefined();
+
+    fetchResult.posts.push({
+      postId: "post-2",
+      redditId: "reddit-2",
+      post: {
+        ...basePost?.post,
+        id: "reddit-2",
+        name: "t3_reddit2",
+        subreddit: "typescript",
+        title: "Test Post 2",
+        selftext: "Body 2",
+        author: "testuser",
+        score: 90,
+        num_comments: 10,
+        url: "https://reddit.com/r/test/2",
+        permalink: "/r/test/2",
+        link_flair_text: null,
+        over_18: false,
+        created_utc: 1700000002,
+        is_self: true,
+      },
+      comments: [],
+    });
+    fetchResult.posts.push({
+      postId: "post-3",
+      redditId: "reddit-3",
+      post: {
+        ...basePost?.post,
+        id: "reddit-3",
+        name: "t3_reddit3",
+        subreddit: "typescript",
+        title: "Test Post 3",
+        selftext: "Body 3",
+        author: "testuser",
+        score: 80,
+        num_comments: 5,
+        url: "https://reddit.com/r/test/3",
+        permalink: "/r/test/3",
+        link_flair_text: null,
+        over_18: false,
+        created_utc: 1700000003,
+        is_self: true,
+      },
+      comments: [],
+    });
+    mockFetchStep.mockResolvedValue(fetchResult);
+
+    mockTriageStep.mockResolvedValue({
+      selected: [
+        { index: 0, relevanceScore: 9, rationale: "R1" },
+        { index: 1, relevanceScore: 8, rationale: "R2" },
+        { index: 2, relevanceScore: 7, rationale: "R3" },
+      ],
+    });
+
+    // Post 1 fails, Post 2 succeeds, Post 3 fails
+    mockSummarizeStep
+      .mockRejectedValueOnce(new Error("Timeout"))
+      .mockResolvedValueOnce(makeSummarizeResult())
+      .mockRejectedValueOnce(new Error("Rate limited"));
+
+    const result = await runDigestPipeline("job-1", [], deps);
+
+    expect(result.status).toBe("PARTIAL");
+    expect(result.subredditResults[0]?.posts).toHaveLength(1);
+    expect(result.subredditResults[0]?.posts[0]?.redditId).toBe("reddit-2");
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0]).toContain("reddit-1");
+    expect(result.errors[0]).toContain("Timeout");
+    expect(result.errors[1]).toContain("reddit-3");
+    expect(result.errors[1]).toContain("Rate limited");
+  });
+});
+
 describe("cancellation checkpoints", () => {
   it("stops before fetch when job is CANCELED", async () => {
     mockDb.job.findUnique.mockResolvedValue({ status: "CANCELED" });

--- a/packages/core/src/pipeline/orchestrator.ts
+++ b/packages/core/src/pipeline/orchestrator.ts
@@ -55,6 +55,40 @@ async function checkCancellation(
   return job?.status === "CANCELED";
 }
 
+/** Default concurrency for parallel post summarization. */
+const SUMMARIZE_CONCURRENCY = 3;
+
+/**
+ * Process items concurrently with a bounded pool size.
+ * Like Promise.allSettled but with a maximum number of in-flight promises.
+ * Safe in single-threaded JS: nextIndex increment is atomic between awaits.
+ */
+async function mapSettled<T, R>(
+  items: T[],
+  fn: (item: T) => Promise<R>,
+  concurrency: number,
+): Promise<Array<PromiseSettledResult<R>>> {
+  const results = new Array<PromiseSettledResult<R>>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const i = nextIndex++;
+      const item = items[i];
+      if (item === undefined) continue;
+      try {
+        results[i] = { status: "fulfilled", value: await fn(item) };
+      } catch (reason) {
+        results[i] = { status: "rejected", reason };
+      }
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
 /**
  * Run the complete digest pipeline.
  *
@@ -275,8 +309,7 @@ async function runPipelineBody(
         jobId,
       );
 
-      // --- Summarize each selected post (per-post error recovery) ---
-      const postResults: SubredditPipelineResult["posts"] = [];
+      // --- Summarize selected posts concurrently (per-post error recovery) ---
 
       // Pre-load embedding module once per subreddit (not per post)
       let generateEmbeddingFn: ((text: string) => Promise<import("@redgest/llm").GenerateResult<number[]>>) | undefined;
@@ -289,16 +322,29 @@ async function runPipelineBody(
         }
       }
 
-      for (const sel of triageResult.selected) {
+      // Build work items (filter out invalid indices)
+      const workItems = triageResult.selected.flatMap((sel) => {
         const postData = newPosts[sel.index];
-        if (!postData) continue;
+        return postData ? [{ sel, postData }] : [];
+      });
 
-        // Checkpoint: before each summarization
-        if (await checkCancellation(jobId, db)) {
-          break;
-        }
+      // Shared cancellation flag — once set, remaining workers skip
+      let canceled = false;
+      const sumModel = runtimeModel ? getModel("summarize", runtimeModel) : undefined;
 
-        try {
+      type PostResult = SubredditPipelineResult["posts"][number];
+      const settled = await mapSettled(
+        workItems,
+        async ({ sel, postData }): Promise<PostResult | null> => {
+          // Skip if cancellation was detected by another concurrent worker
+          if (canceled) return null;
+
+          // Checkpoint: check cancellation before starting this post
+          if (await checkCancellation(jobId, db)) {
+            canceled = true;
+            return null;
+          }
+
           const sumComments: SummarizationComment[] =
             postData.comments.map((c) => ({
               author: c.author,
@@ -306,7 +352,6 @@ async function runPipelineBody(
               body: c.body,
             }));
 
-          const sumModel = runtimeModel ? getModel("summarize", runtimeModel) : undefined;
           const sumResult = await summarizeStep(
             {
               title: postData.post.title,
@@ -364,17 +409,29 @@ async function runPipelineBody(
             );
           }
 
-          postResults.push({
+          return {
             postId: postData.postId,
             redditId: postData.redditId,
             title: postData.post.title,
             summary: sumResult.summary,
             selectionRationale: sel.rationale,
-          });
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
+          };
+        },
+        SUMMARIZE_CONCURRENCY,
+      );
+
+      // Collect results and errors from settled promises
+      const postResults: SubredditPipelineResult["posts"] = [];
+      for (let i = 0; i < settled.length; i++) {
+        const s = settled[i];
+        if (!s) continue;
+        if (s.status === "fulfilled" && s.value !== null) {
+          postResults.push(s.value);
+        } else if (s.status === "rejected") {
+          const workItem = workItems[i];
+          const msg = s.reason instanceof Error ? s.reason.message : String(s.reason);
           errors.push(
-            `Failed to summarize post ${postData.redditId}: ${msg}`,
+            `Failed to summarize post ${workItem?.postData.redditId}: ${msg}`,
           );
         }
       }


### PR DESCRIPTION
Closes #40

Replaces sequential summarization loop with bounded-concurrency pool (3 workers). Each post's summarization, embedding, and topic extraction run as a concurrent unit. Per-post error recovery and cancellation checkpoints preserved.

Generated with [Claude Code](https://claude.ai/code)