### PR TITLE
Add LLM-powered prose generation for digest delivery

### DIFF
--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -21,5 +21,5 @@
     "**/*.tsx",
     ".next/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "tests"]
 }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -19,6 +19,7 @@
     "@redgest/core": "workspace:*",
     "@redgest/db": "workspace:*",
     "@redgest/email": "workspace:*",
+    "@redgest/llm": "workspace:*",
     "@redgest/reddit": "workspace:*",
     "@redgest/slack": "workspace:*",
     "@trigger.dev/sdk": "^4.4.3"

--- a/apps/worker/src/trigger/deliver-digest.ts
+++ b/apps/worker/src/trigger/deliver-digest.ts
@@ -7,8 +7,10 @@ import {
   type DeliveryTransactionClient,
 } from "@redgest/core";
 import { prisma } from "@redgest/db";
-import { sendDigestEmail, buildDeliveryData } from "@redgest/email";
+import { sendDigestEmail, buildDeliveryData, buildFormattedDigest } from "@redgest/email";
 import { sendDigestSlack } from "@redgest/slack";
+import { generateDeliveryProse } from "@redgest/llm";
+import type { DeliveryDigestInput } from "@redgest/llm";
 
 export const deliverDigest = task({
   id: "deliver-digest",
@@ -35,6 +37,21 @@ export const deliverDigest = task({
 
     const deliveryData = buildDeliveryData(digest);
 
+    // Map to LLM input (drop fields the LLM doesn't need)
+    const llmInput: DeliveryDigestInput = {
+      subreddits: deliveryData.subreddits.map((s) => ({
+        name: s.name,
+        posts: s.posts.map((p) => ({
+          title: p.title,
+          score: p.score,
+          summary: p.summary,
+          keyTakeaways: p.keyTakeaways,
+          insightNotes: p.insightNotes,
+          commentHighlights: p.commentHighlights,
+        })),
+      })),
+    };
+
     // Dispatch to configured channels
     const channels: Array<{
       name: string;
@@ -47,8 +64,11 @@ export const deliverDigest = task({
       channels.push({
         name: "email",
         type: "EMAIL",
-        send: () =>
-          sendDigestEmail(deliveryData, DELIVERY_EMAIL, RESEND_API_KEY),
+        send: async () => {
+          const { data: prose } = await generateDeliveryProse(llmInput, "email");
+          const formatted = buildFormattedDigest(deliveryData, prose);
+          return sendDigestEmail(formatted, DELIVERY_EMAIL, RESEND_API_KEY);
+        },
       });
     }
 
@@ -57,7 +77,11 @@ export const deliverDigest = task({
       channels.push({
         name: "slack",
         type: "SLACK",
-        send: () => sendDigestSlack(deliveryData, webhookUrl),
+        send: async () => {
+          const { data: prose } = await generateDeliveryProse(llmInput, "slack");
+          const formatted = buildFormattedDigest(deliveryData, prose);
+          return sendDigestSlack(formatted, webhookUrl);
+        },
       });
     }
 

--- a/packages/email/src/__tests__/render.test.ts
+++ b/packages/email/src/__tests__/render.test.ts
@@ -10,24 +10,21 @@ vi.mock("../template.js", () => ({
   DigestEmail: vi.fn().mockReturnValue(null),
 }));
 
-import type { DigestDeliveryData } from "../types.js";
+import type { FormattedDigest } from "../types.js";
 
-function makeDigest(): DigestDeliveryData {
+function makeDigest(): FormattedDigest {
   return {
-    digestId: "digest-001",
     createdAt: new Date("2026-03-10T12:00:00Z"),
-    subreddits: [
+    headline: "Today's top posts across your subreddits.",
+    sections: [
       {
-        name: "typescript",
+        subreddit: "typescript",
+        body: "TypeScript community highlights.",
         posts: [
           {
             title: "Test Post",
             permalink: "/r/typescript/comments/abc/test",
             score: 100,
-            summary: "A test post.",
-            keyTakeaways: ["takeaway"],
-            insightNotes: "notes",
-            commentHighlights: [],
           },
         ],
       },

--- a/packages/email/src/__tests__/send.test.ts
+++ b/packages/email/src/__tests__/send.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { DigestDeliveryData } from "../types.js";
+import type { FormattedDigest } from "../types.js";
 
 const mockSend = vi.fn();
 
@@ -21,22 +21,19 @@ vi.mock("../render.js", () => ({
   renderDigestHtml: vi.fn().mockResolvedValue("<html>rendered</html>"),
 }));
 
-function makeDigest(): DigestDeliveryData {
+function makeDigest(): FormattedDigest {
   return {
-    digestId: "digest-001",
     createdAt: new Date("2026-03-10T12:00:00Z"),
-    subreddits: [
+    headline: "Today's top posts across your subreddits.",
+    sections: [
       {
-        name: "typescript",
+        subreddit: "typescript",
+        body: "TypeScript community highlights.",
         posts: [
           {
             title: "Test Post",
             permalink: "/r/typescript/comments/abc/test",
             score: 100,
-            summary: "A test post.",
-            keyTakeaways: ["takeaway"],
-            insightNotes: "notes",
-            commentHighlights: [],
           },
         ],
       },

--- a/packages/email/src/__tests__/template.test.tsx
+++ b/packages/email/src/__tests__/template.test.tsx
@@ -1,33 +1,23 @@
 import { describe, it, expect } from "vitest";
 import { render } from "@react-email/components";
 import { DigestEmail } from "../template.js";
-import type { DigestDeliveryData } from "../types.js";
+import type { FormattedDigest } from "../types.js";
 
-function makeDigest(overrides?: Partial<DigestDeliveryData>): DigestDeliveryData {
+function makeDigest(overrides?: Partial<FormattedDigest>): FormattedDigest {
   return {
-    digestId: "digest-001",
     createdAt: new Date("2026-03-10T12:00:00Z"),
-    subreddits: [
+    headline:
+      "TypeScript 6.0 lands with major type inference improvements and faster compilation.",
+    sections: [
       {
-        name: "typescript",
+        subreddit: "typescript",
+        body: "The community is buzzing about TypeScript 6.0, which brings new control flow analysis and faster compilation. Several developers noted its impact on monorepo tooling.",
         posts: [
           {
             title: "TypeScript 6.0 Released",
-            permalink: "/r/typescript/comments/abc123/typescript_60_released",
+            permalink:
+              "/r/typescript/comments/abc123/typescript_60_released",
             score: 542,
-            summary: "TypeScript 6.0 brings major improvements to type inference.",
-            keyTakeaways: [
-              "New control flow analysis",
-              "Faster compilation",
-            ],
-            insightNotes: "Relevant to our project migration timeline.",
-            commentHighlights: [
-              {
-                author: "devguru",
-                insight: "The new inference is a game changer for monorepos.",
-                score: 128,
-              },
-            ],
           },
         ],
       },
@@ -71,54 +61,53 @@ describe("DigestEmail template", () => {
     );
   });
 
-  it("contains key takeaways", async () => {
+  it("contains the headline", async () => {
     const digest = makeDigest();
     const html = await render(<DigestEmail digest={digest} />);
-    expect(html).toContain("New control flow analysis");
-    expect(html).toContain("Faster compilation");
+    expect(html).toContain(
+      "TypeScript 6.0 lands with major type inference improvements",
+    );
   });
 
-  it("contains insight notes", async () => {
+  it("contains per-subreddit prose body", async () => {
     const digest = makeDigest();
     const html = await render(<DigestEmail digest={digest} />);
-    expect(html).toContain("Relevant to our project migration timeline.");
+    expect(html).toContain("community is buzzing about TypeScript 6.0");
+    expect(html).toContain("new control flow analysis and faster compilation");
   });
 
-  it("contains comment highlights", async () => {
+  it("contains post links with scores", async () => {
     const digest = makeDigest();
     const html = await render(<DigestEmail digest={digest} />);
-    expect(html).toContain("devguru");
-    expect(html).toContain("game changer for monorepos");
+    expect(html).toContain("TypeScript 6.0 Released");
+    expect(html).toContain("542");
+    expect(html).toContain(
+      "https://reddit.com/r/typescript/comments/abc123/typescript_60_released",
+    );
   });
 
   it("renders multiple subreddits", async () => {
     const digest = makeDigest({
-      subreddits: [
+      sections: [
         {
-          name: "typescript",
+          subreddit: "typescript",
+          body: "TypeScript news and updates.",
           posts: [
             {
               title: "Post A",
               permalink: "/r/typescript/comments/a/post_a",
               score: 10,
-              summary: "Summary A",
-              keyTakeaways: [],
-              insightNotes: "",
-              commentHighlights: [],
             },
           ],
         },
         {
-          name: "rust",
+          subreddit: "rust",
+          body: "Rust ecosystem developments.",
           posts: [
             {
               title: "Post B",
               permalink: "/r/rust/comments/b/post_b",
               score: 20,
-              summary: "Summary B",
-              keyTakeaways: [],
-              insightNotes: "",
-              commentHighlights: [],
             },
           ],
         },
@@ -131,27 +120,18 @@ describe("DigestEmail template", () => {
     expect(html).toContain("Post B");
   });
 
-  it("handles empty key takeaways gracefully", async () => {
+  it("handles empty posts array gracefully", async () => {
     const digest = makeDigest({
-      subreddits: [
+      sections: [
         {
-          name: "test",
-          posts: [
-            {
-              title: "Minimal Post",
-              permalink: "/r/test/comments/x/minimal",
-              score: 1,
-              summary: "A minimal post.",
-              keyTakeaways: [],
-              insightNotes: "",
-              commentHighlights: [],
-            },
-          ],
+          subreddit: "test",
+          body: "A section with no post links.",
+          posts: [],
         },
       ],
     });
     const html = await render(<DigestEmail digest={digest} />);
-    expect(html).toContain("Minimal Post");
-    expect(html).not.toContain("Key Takeaways");
+    expect(html).toContain("test");
+    expect(html).toContain("A section with no post links.");
   });
 });

--- a/packages/email/src/__tests__/transform.test.ts
+++ b/packages/email/src/__tests__/transform.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { buildDeliveryData, type DigestWithRelations } from "../transform.js";
+import {
+  buildDeliveryData,
+  buildFormattedDigest,
+  type DigestWithRelations,
+} from "../transform.js";
+import type { DigestDeliveryData } from "../types.js";
 
 function makeDigestWithRelations(
   overrides?: Partial<DigestWithRelations>,
@@ -221,5 +226,119 @@ describe("buildDeliveryData", () => {
     expect(post.score).toBe(300);
     expect(post.summary).toBe("Rust edition 2026.");
     expect(post.insightNotes).toBe("Edition release");
+  });
+});
+
+function makeDeliveryData(
+  overrides?: Partial<DigestDeliveryData>,
+): DigestDeliveryData {
+  return {
+    digestId: "digest-001",
+    createdAt: new Date("2026-03-10T12:00:00Z"),
+    subreddits: [
+      {
+        name: "typescript",
+        posts: [
+          {
+            title: "TS 6.0 Released",
+            permalink: "/r/typescript/comments/abc/ts-60",
+            score: 250,
+            summary: "TypeScript 6.0 adds new features.",
+            keyTakeaways: ["Better types", "Faster compiler"],
+            insightNotes: "Major release",
+            commentHighlights: [
+              { author: "dev1", insight: "Great update", score: 50 },
+            ],
+          },
+        ],
+      },
+      {
+        name: "rust",
+        posts: [
+          {
+            title: "Rust 2026",
+            permalink: "/r/rust/comments/ghi/rust-2026",
+            score: 300,
+            summary: "Rust edition 2026.",
+            keyTakeaways: [],
+            insightNotes: "Edition release",
+            commentHighlights: [],
+          },
+        ],
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("buildFormattedDigest", () => {
+  it("merges prose headline and sections with post links from delivery data", () => {
+    const data = makeDeliveryData();
+    const prose = {
+      headline: "Big week for TypeScript and Rust.",
+      sections: [
+        { subreddit: "typescript", body: "TS 6.0 dropped with major improvements." },
+        { subreddit: "rust", body: "Rust edition 2026 is here." },
+      ],
+    };
+
+    const result = buildFormattedDigest(data, prose);
+
+    expect(result.headline).toBe("Big week for TypeScript and Rust.");
+    expect(result.sections).toHaveLength(2);
+
+    const tsSection = result.sections[0];
+    expect(tsSection).toBeDefined();
+    if (!tsSection) return;
+    expect(tsSection.subreddit).toBe("typescript");
+    expect(tsSection.body).toBe("TS 6.0 dropped with major improvements.");
+    expect(tsSection.posts).toHaveLength(1);
+    const tsPost = tsSection.posts[0];
+    expect(tsPost).toBeDefined();
+    if (!tsPost) return;
+    expect(tsPost.title).toBe("TS 6.0 Released");
+    expect(tsPost.permalink).toBe("/r/typescript/comments/abc/ts-60");
+    expect(tsPost.score).toBe(250);
+
+    const rustSection = result.sections[1];
+    expect(rustSection).toBeDefined();
+    if (!rustSection) return;
+    expect(rustSection.subreddit).toBe("rust");
+    expect(rustSection.body).toBe("Rust edition 2026 is here.");
+    expect(rustSection.posts).toHaveLength(1);
+  });
+
+  it("handles missing subreddit in delivery data by falling back to empty posts", () => {
+    const data = makeDeliveryData();
+    const prose = {
+      headline: "Highlights from the week.",
+      sections: [
+        { subreddit: "golang", body: "Go news this week." },
+      ],
+    };
+
+    const result = buildFormattedDigest(data, prose);
+
+    expect(result.sections).toHaveLength(1);
+    const goSection = result.sections[0];
+    expect(goSection).toBeDefined();
+    if (!goSection) return;
+    expect(goSection.subreddit).toBe("golang");
+    expect(goSection.body).toBe("Go news this week.");
+    expect(goSection.posts).toEqual([]);
+  });
+
+  it("preserves createdAt from delivery data", () => {
+    const data = makeDeliveryData({
+      createdAt: new Date("2026-06-15T08:30:00Z"),
+    });
+    const prose = {
+      headline: "Mid-year digest.",
+      sections: [],
+    };
+
+    const result = buildFormattedDigest(data, prose);
+
+    expect(result.createdAt).toEqual(new Date("2026-06-15T08:30:00Z"));
   });
 });

--- a/packages/email/src/index.ts
+++ b/packages/email/src/index.ts
@@ -1,5 +1,5 @@
 export { sendDigestEmail } from "./send.js";
 export { renderDigestHtml } from "./render.js";
 export { DigestEmail } from "./template.js";
-export type { DigestDeliveryData } from "./types.js";
-export { buildDeliveryData, type DigestWithRelations } from "./transform.js";
+export type { DigestDeliveryData, FormattedDigest } from "./types.js";
+export { buildDeliveryData, buildFormattedDigest, type DigestWithRelations } from "./transform.js";

--- a/packages/email/src/render.ts
+++ b/packages/email/src/render.ts
@@ -1,14 +1,14 @@
 import { createElement } from "react";
 import { render } from "@react-email/components";
 import { DigestEmail } from "./template.js";
-import type { DigestDeliveryData } from "./types.js";
+import type { FormattedDigest } from "./types.js";
 
 /**
  * Render a digest as HTML using the DigestEmail React Email template.
  * Does NOT send — use sendDigestEmail() for delivery.
  */
 export async function renderDigestHtml(
-  data: DigestDeliveryData,
+  data: FormattedDigest,
 ): Promise<string> {
   return render(createElement(DigestEmail, { digest: data }));
 }

--- a/packages/email/src/send.ts
+++ b/packages/email/src/send.ts
@@ -1,9 +1,9 @@
 import { Resend } from "resend";
-import type { DigestDeliveryData } from "./types.js";
+import type { FormattedDigest } from "./types.js";
 import { renderDigestHtml } from "./render.js";
 
 export async function sendDigestEmail(
-  digest: DigestDeliveryData,
+  digest: FormattedDigest,
   recipientEmail: string,
   apiKey: string,
 ): Promise<{ id: string }> {

--- a/packages/email/src/template.tsx
+++ b/packages/email/src/template.tsx
@@ -9,10 +9,10 @@ import {
   Hr,
   Link,
 } from "@react-email/components";
-import type { DigestDeliveryData } from "./types.js";
+import type { FormattedDigest } from "./types.js";
 
 interface DigestEmailProps {
-  digest: DigestDeliveryData;
+  digest: FormattedDigest;
 }
 
 export function DigestEmail({ digest }: DigestEmailProps) {
@@ -24,63 +24,32 @@ export function DigestEmail({ digest }: DigestEmailProps) {
       <Body style={{ fontFamily: "system-ui, sans-serif", color: "#333" }}>
         <Container style={{ maxWidth: "600px", margin: "0 auto" }}>
           <Heading as="h1">Reddit Digest — {dateStr}</Heading>
+          <Text style={{ fontSize: "16px", lineHeight: "1.6" }}>
+            {digest.headline}
+          </Text>
+          <Hr />
 
-          {digest.subreddits.map((sub) => (
-            <Section key={sub.name}>
-              <Heading as="h2">r/{sub.name}</Heading>
-              <Hr />
-              {sub.posts.map((post) => (
-                <Section key={post.permalink} style={{ marginBottom: "24px" }}>
-                  <Heading as="h3">
-                    <Link href={`https://reddit.com${post.permalink}`}>
-                      {post.title}
-                    </Link>
-                  </Heading>
-                  <Text style={{ fontSize: "14px", color: "#666" }}>
-                    {post.score} pts
-                  </Text>
-                  <Text>{post.summary}</Text>
-                  {post.keyTakeaways.length > 0 && (
-                    <Section>
-                      <Text
-                        style={{ fontWeight: "bold", marginBottom: "4px" }}
-                      >
-                        Key Takeaways:
-                      </Text>
-                      {post.keyTakeaways.map((t, i) => (
-                        <Text key={i} style={{ margin: "2px 0 2px 16px" }}>
-                          - {t}
-                        </Text>
-                      ))}
-                    </Section>
-                  )}
-                  {post.insightNotes && (
-                    <Text style={{ fontStyle: "italic", color: "#555" }}>
-                      {post.insightNotes}
+          {digest.sections.map((section) => (
+            <Section key={section.subreddit} style={{ marginBottom: "24px" }}>
+              <Heading as="h2">r/{section.subreddit}</Heading>
+              <Text style={{ fontSize: "15px", lineHeight: "1.6" }}>
+                {section.body}
+              </Text>
+              {section.posts.length > 0 && (
+                <Section style={{ marginTop: "8px" }}>
+                  {section.posts.map((post) => (
+                    <Text
+                      key={post.permalink}
+                      style={{ margin: "4px 0", fontSize: "14px" }}
+                    >
+                      <Link href={`https://reddit.com${post.permalink}`}>
+                        {post.title}
+                      </Link>{" "}
+                      <span style={{ color: "#888" }}>({post.score} pts)</span>
                     </Text>
-                  )}
-                  {post.commentHighlights.length > 0 && (
-                    <Section>
-                      <Text
-                        style={{ fontWeight: "bold", marginBottom: "4px" }}
-                      >
-                        Comment Highlights:
-                      </Text>
-                      {post.commentHighlights.map((c, i) => (
-                        <Text
-                          key={i}
-                          style={{
-                            margin: "4px 0 4px 16px",
-                            fontSize: "14px",
-                          }}
-                        >
-                          u/{c.author} ({c.score} pts): {c.insight}
-                        </Text>
-                      ))}
-                    </Section>
-                  )}
+                  ))}
                 </Section>
-              ))}
+              )}
             </Section>
           ))}
         </Container>

--- a/packages/email/src/transform.ts
+++ b/packages/email/src/transform.ts
@@ -1,4 +1,4 @@
-import type { DigestDeliveryData } from "./types.js";
+import type { DigestDeliveryData, FormattedDigest } from "./types.js";
 
 /**
  * Input type for buildDeliveryData.
@@ -89,5 +89,31 @@ export function buildDeliveryData(
     digestId: digest.id,
     createdAt: digest.createdAt,
     subreddits: Array.from(subredditMap.values()),
+  };
+}
+
+/**
+ * Merge LLM-generated prose with post links from DigestDeliveryData
+ * to produce the FormattedDigest consumed by email/Slack templates.
+ */
+export function buildFormattedDigest(
+  data: DigestDeliveryData,
+  prose: { headline: string; sections: Array<{ subreddit: string; body: string }> },
+): FormattedDigest {
+  return {
+    createdAt: data.createdAt,
+    headline: prose.headline,
+    sections: prose.sections.map((s) => {
+      const sub = data.subreddits.find((sub) => sub.name === s.subreddit);
+      return {
+        subreddit: s.subreddit,
+        body: s.body,
+        posts: (sub?.posts ?? []).map((p) => ({
+          title: p.title,
+          permalink: p.permalink,
+          score: p.score,
+        })),
+      };
+    }),
   };
 }

--- a/packages/email/src/types.ts
+++ b/packages/email/src/types.ts
@@ -18,3 +18,13 @@ export interface DigestDeliveryData {
     }>;
   }>;
 }
+
+export interface FormattedDigest {
+  createdAt: Date;
+  headline: string;
+  sections: Array<{
+    subreddit: string;
+    body: string;
+    posts: Array<{ title: string; permalink: string; score: number }>;
+  }>;
+}

--- a/packages/llm/src/__tests__/delivery-prompts.test.ts
+++ b/packages/llm/src/__tests__/delivery-prompts.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildDeliverySystemPrompt,
+  buildDeliveryUserPrompt,
+} from "../prompts/delivery.js";
+import type { DeliveryDigestInput } from "../prompts/delivery.js";
+
+describe("buildDeliverySystemPrompt", () => {
+  it("produces email-specific instructions mentioning newsletter", () => {
+    const prompt = buildDeliverySystemPrompt("email");
+    expect(prompt).toContain("newsletter");
+  });
+
+  it("email prompt is longer than slack prompt", () => {
+    const emailPrompt = buildDeliverySystemPrompt("email");
+    const slackPrompt = buildDeliverySystemPrompt("slack");
+    expect(emailPrompt.length).toBeGreaterThan(slackPrompt.length);
+  });
+
+  it("produces slack-specific instructions mentioning ultra-concise", () => {
+    const prompt = buildDeliverySystemPrompt("slack");
+    expect(prompt).toContain("ultra-concise");
+  });
+
+  it("email prompt includes structure guidance", () => {
+    const prompt = buildDeliverySystemPrompt("email");
+    expect(prompt).toContain("headline");
+    expect(prompt).toContain("sections");
+  });
+
+  it("slack prompt includes structure guidance", () => {
+    const prompt = buildDeliverySystemPrompt("slack");
+    expect(prompt).toContain("headline");
+    expect(prompt).toContain("sections");
+  });
+});
+
+describe("buildDeliveryUserPrompt", () => {
+  const fullInput: DeliveryDigestInput = {
+    subreddits: [
+      {
+        name: "typescript",
+        posts: [
+          {
+            title: "TypeScript 6.0 Released",
+            score: 500,
+            summary: "Major performance improvements in TypeScript 6.0.",
+            keyTakeaways: [
+              "50% faster compilation",
+              "Improved type inference",
+            ],
+            insightNotes: "Directly relevant to your monorepo workflow.",
+            commentHighlights: [
+              {
+                author: "tsdev",
+                insight: "Game changer for large codebases",
+                score: 120,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        name: "golang",
+        posts: [
+          {
+            title: "Go 2.0 Generics Deep Dive",
+            score: 320,
+            summary: "Detailed analysis of Go 2.0 generics implementation.",
+            keyTakeaways: ["Type parameters now support constraints"],
+            insightNotes: "Interesting comparison to TypeScript generics.",
+            commentHighlights: [],
+          },
+        ],
+      },
+    ],
+  };
+
+  it("includes subreddit names", () => {
+    const prompt = buildDeliveryUserPrompt(fullInput);
+    expect(prompt).toContain("r/typescript");
+    expect(prompt).toContain("r/golang");
+  });
+
+  it("includes post titles", () => {
+    const prompt = buildDeliveryUserPrompt(fullInput);
+    expect(prompt).toContain("TypeScript 6.0 Released");
+    expect(prompt).toContain("Go 2.0 Generics Deep Dive");
+  });
+
+  it("includes post summaries", () => {
+    const prompt = buildDeliveryUserPrompt(fullInput);
+    expect(prompt).toContain("Major performance improvements in TypeScript 6.0.");
+    expect(prompt).toContain("Detailed analysis of Go 2.0 generics implementation.");
+  });
+
+  it("includes key takeaways", () => {
+    const prompt = buildDeliveryUserPrompt(fullInput);
+    expect(prompt).toContain("50% faster compilation");
+    expect(prompt).toContain("Improved type inference");
+    expect(prompt).toContain("Type parameters now support constraints");
+  });
+
+  it("includes insight notes", () => {
+    const prompt = buildDeliveryUserPrompt(fullInput);
+    expect(prompt).toContain("Directly relevant to your monorepo workflow.");
+    expect(prompt).toContain("Interesting comparison to TypeScript generics.");
+  });
+
+  it("includes comment highlights with author and insight", () => {
+    const prompt = buildDeliveryUserPrompt(fullInput);
+    expect(prompt).toContain("u/tsdev");
+    expect(prompt).toContain("Game changer for large codebases");
+    expect(prompt).toContain("120");
+  });
+
+  it("handles minimal input with empty subreddits array", () => {
+    const emptyInput: DeliveryDigestInput = { subreddits: [] };
+    const prompt = buildDeliveryUserPrompt(emptyInput);
+    expect(prompt).toBeDefined();
+    expect(typeof prompt).toBe("string");
+  });
+
+  it("handles subreddit with empty posts array", () => {
+    const emptyPostsInput: DeliveryDigestInput = {
+      subreddits: [{ name: "empty_sub", posts: [] }],
+    };
+    const prompt = buildDeliveryUserPrompt(emptyPostsInput);
+    expect(prompt).toContain("r/empty_sub");
+  });
+
+  it("handles post with empty arrays for takeaways and highlights", () => {
+    const minimalPostInput: DeliveryDigestInput = {
+      subreddits: [
+        {
+          name: "minimal",
+          posts: [
+            {
+              title: "Minimal Post",
+              score: 10,
+              summary: "A minimal post.",
+              keyTakeaways: [],
+              insightNotes: "",
+              commentHighlights: [],
+            },
+          ],
+        },
+      ],
+    };
+    const prompt = buildDeliveryUserPrompt(minimalPostInput);
+    expect(prompt).toContain("Minimal Post");
+    expect(prompt).toContain("A minimal post.");
+  });
+});

--- a/packages/llm/src/__tests__/generate-delivery-prose.test.ts
+++ b/packages/llm/src/__tests__/generate-delivery-prose.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGenerateText } = vi.hoisted(() => ({
+  mockGenerateText: vi.fn(),
+}));
+
+vi.mock("ai", () => ({
+  generateText: mockGenerateText,
+  Output: {
+    object: vi.fn((opts: { schema: unknown }) => ({
+      type: "object",
+      schema: opts.schema,
+    })),
+  },
+}));
+
+vi.mock("../provider.js", () => ({
+  getModel: vi.fn(() => ({ provider: "mock", modelId: "mock-model" })),
+}));
+
+vi.mock("../cache.js", () => ({
+  withCache: vi.fn(
+    async (
+      _taskType: string,
+      _inputs: unknown,
+      fn: () => Promise<unknown>,
+    ) => ({ data: await fn(), cached: false }),
+  ),
+}));
+
+import { generateDeliveryProse } from "../generate-delivery-prose.js";
+import { withCache } from "../cache.js";
+import type { DeliveryDigestInput } from "../prompts/delivery.js";
+
+const sampleInput: DeliveryDigestInput = {
+  subreddits: [
+    {
+      name: "typescript",
+      posts: [
+        {
+          title: "TypeScript 6.0 Released",
+          score: 500,
+          summary: "TypeScript 6.0 brings major performance improvements.",
+          keyTakeaways: ["50% faster compilation", "New type inference"],
+          insightNotes: "Relevant to your TypeScript workflow.",
+          commentHighlights: [
+            { author: "tsdev", insight: "Game changer for monorepos", score: 120 },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const sampleProseResult = {
+  headline: "TypeScript 6.0 drops with massive performance wins.",
+  sections: [
+    {
+      subreddit: "typescript",
+      body: "The big news is TypeScript 6.0, which brings 50% faster compilation.",
+    },
+  ],
+};
+
+describe("generateDeliveryProse", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls generateText with the correct system prompt for email channel", async () => {
+    mockGenerateText.mockResolvedValue({ output: sampleProseResult });
+
+    const result = await generateDeliveryProse(sampleInput, "email");
+
+    expect(result.data).toEqual(sampleProseResult);
+    expect(result.log).not.toBeNull();
+    expect(result.log?.task).toBe("delivery-email");
+    expect(mockGenerateText).toHaveBeenCalledOnce();
+
+    const callArgs = mockGenerateText.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArgs.model).toBeDefined();
+    expect(callArgs.system).toContain("newsletter");
+    expect(callArgs.prompt).toContain("TypeScript 6.0 Released");
+    expect(callArgs.output).toBeDefined();
+  });
+
+  it("calls generateText with the correct system prompt for slack channel", async () => {
+    mockGenerateText.mockResolvedValue({ output: sampleProseResult });
+
+    const result = await generateDeliveryProse(sampleInput, "slack");
+
+    expect(result.data).toEqual(sampleProseResult);
+    expect(result.log).not.toBeNull();
+    expect(result.log?.task).toBe("delivery-slack");
+
+    const callArgs = mockGenerateText.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArgs.system).toContain("ultra-concise");
+  });
+
+  it("includes channel name in cache key", async () => {
+    mockGenerateText.mockResolvedValue({ output: sampleProseResult });
+
+    await generateDeliveryProse(sampleInput, "email");
+
+    const mockWithCache = vi.mocked(withCache);
+    expect(mockWithCache).toHaveBeenCalledOnce();
+    const cacheKey = mockWithCache.mock.calls[0]?.[0] as string;
+    expect(cacheKey).toBe("delivery-email");
+
+    vi.clearAllMocks();
+    mockGenerateText.mockResolvedValue({ output: sampleProseResult });
+
+    await generateDeliveryProse(sampleInput, "slack");
+
+    expect(mockWithCache).toHaveBeenCalledOnce();
+    const slackCacheKey = mockWithCache.mock.calls[0]?.[0] as string;
+    expect(slackCacheKey).toBe("delivery-slack");
+  });
+
+  it("accepts custom model override", async () => {
+    mockGenerateText.mockResolvedValue({ output: sampleProseResult });
+
+    const customModel = { provider: "custom", modelId: "custom-model" };
+    await generateDeliveryProse(
+      sampleInput,
+      "email",
+      customModel as Parameters<typeof generateDeliveryProse>[2],
+    );
+
+    const callArgs = mockGenerateText.mock.calls[0]?.[0] as Record<
+      string,
+      unknown
+    >;
+    expect(callArgs.model).toBe(customModel);
+  });
+});

--- a/packages/llm/src/__tests__/schemas.test.ts
+++ b/packages/llm/src/__tests__/schemas.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { TriageResultSchema, PostSummarySchema } from "../schemas.js";
+import { TriageResultSchema, PostSummarySchema, DeliveryProseSchema } from "../schemas.js";
 
 describe("TriageResultSchema", () => {
   it("validates correct triage result", () => {
@@ -128,6 +128,72 @@ describe("PostSummarySchema", () => {
       commentHighlights: [{ insight: "Good point", score: 10 }],
     };
     const result = PostSummarySchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("DeliveryProseSchema", () => {
+  const validProse = {
+    headline: "TypeScript 6.0 dominates this week's digest with massive performance improvements across the board.",
+    sections: [
+      {
+        subreddit: "typescript",
+        body: "The TypeScript 6.0 release brought 50% faster compilation and improved type inference, generating significant community excitement.",
+      },
+      {
+        subreddit: "golang",
+        body: "Go 2.0's generics deep dive revealed practical patterns for type constraints that mirror TypeScript's approach.",
+      },
+    ],
+  };
+
+  it("validates complete delivery prose", () => {
+    const result = DeliveryProseSchema.safeParse(validProse);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.headline).toContain("TypeScript");
+      expect(result.data.sections).toHaveLength(2);
+      const first = result.data.sections[0];
+      if (!first) throw new Error("Expected at least one section");
+      expect(first.subreddit).toBe("typescript");
+      expect(first.body).toContain("compilation");
+    }
+  });
+
+  it("accepts empty sections array", () => {
+    const withEmpty = { headline: "Nothing notable this period.", sections: [] };
+    const result = DeliveryProseSchema.safeParse(withEmpty);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.sections).toHaveLength(0);
+    }
+  });
+
+  it("rejects missing headline", () => {
+    const invalid = {
+      sections: [
+        { subreddit: "typescript", body: "Some content." },
+      ],
+    };
+    const result = DeliveryProseSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects section without subreddit", () => {
+    const invalid = {
+      headline: "A headline.",
+      sections: [{ body: "Some content without subreddit." }],
+    };
+    const result = DeliveryProseSchema.safeParse(invalid);
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects section without body", () => {
+    const invalid = {
+      headline: "A headline.",
+      sections: [{ subreddit: "typescript" }],
+    };
+    const result = DeliveryProseSchema.safeParse(invalid);
     expect(result.success).toBe(false);
   });
 });

--- a/packages/llm/src/cache.ts
+++ b/packages/llm/src/cache.ts
@@ -38,6 +38,8 @@ export function hashKey(prefix: string, data: unknown): string {
 const TTL = {
   triage: 2 * 60 * 60, // 2 hours
   summary: 7 * 24 * 60 * 60, // 7 days
+  "delivery-email": 7 * 24 * 60 * 60, // 7 days
+  "delivery-slack": 7 * 24 * 60 * 60, // 7 days
 } as const;
 
 export interface CacheResult<T> {

--- a/packages/llm/src/generate-delivery-prose.ts
+++ b/packages/llm/src/generate-delivery-prose.ts
@@ -1,0 +1,49 @@
+import type { LanguageModel } from "ai";
+import { DeliveryProseSchema } from "./schemas.js";
+import type { DeliveryProse } from "./schemas.js";
+import {
+  buildDeliverySystemPrompt,
+  buildDeliveryUserPrompt,
+} from "./prompts/index.js";
+import type { DeliveryDigestInput, DeliveryChannel } from "./prompts/index.js";
+import { getModel } from "./provider.js";
+import { withCache } from "./cache.js";
+import { generateWithLogging } from "./middleware.js";
+import type { GenerateResult, LlmCallLog } from "./middleware.js";
+
+export async function generateDeliveryProse(
+  input: DeliveryDigestInput,
+  channel: DeliveryChannel,
+  model?: LanguageModel,
+): Promise<GenerateResult<DeliveryProse>> {
+  const resolvedModel = model ?? getModel("delivery");
+  const system = buildDeliverySystemPrompt(channel);
+  const prompt = buildDeliveryUserPrompt(input);
+
+  let llmLog: LlmCallLog | null = null;
+
+  const { data, cached } = await withCache(
+    `delivery-${channel}`,
+    { input, channel },
+    async () => {
+      const { output, log } = await generateWithLogging({
+        task: `delivery-${channel}`,
+        model: resolvedModel,
+        system,
+        prompt,
+        schema: DeliveryProseSchema,
+      });
+      llmLog = log;
+      return output;
+    },
+  );
+
+  if (cached) {
+    // eslint-disable-next-line no-console -- structured LLM call log for observability
+    console.log(
+      JSON.stringify({ type: "llm_call", task: `delivery-${channel}`, cached: true, durationMs: 0 }),
+    );
+  }
+
+  return { data, log: llmLog };
+}

--- a/packages/llm/src/index.ts
+++ b/packages/llm/src/index.ts
@@ -3,6 +3,8 @@ export {
   buildTriageUserPrompt,
   buildSummarizationSystemPrompt,
   buildSummarizationUserPrompt,
+  buildDeliverySystemPrompt,
+  buildDeliveryUserPrompt,
   sanitizeForPrompt,
 } from "./prompts/index.js";
 
@@ -10,15 +12,18 @@ export type {
   TriagePostCandidate,
   SummarizationPost,
   SummarizationComment,
+  DeliveryDigestInput,
+  DeliveryChannel,
 } from "./prompts/index.js";
 
-export { TriageResultSchema, PostSummarySchema } from "./schemas.js";
-export type { TriageResult, PostSummary } from "./schemas.js";
+export { TriageResultSchema, PostSummarySchema, DeliveryProseSchema } from "./schemas.js";
+export type { TriageResult, PostSummary, DeliveryProse } from "./schemas.js";
 export type { CandidatePost, SummarizationInput } from "./types.js";
 
 export { getModel, type ModelConfig } from "./provider.js";
 export { generateTriageResult } from "./generate-triage.js";
 export { generatePostSummary } from "./generate-summary.js";
+export { generateDeliveryProse } from "./generate-delivery-prose.js";
 
 export { withCache, disconnectCache, type CacheResult } from "./cache.js";
 export { generateWithLogging, type LlmCallLog, type GenerateResult } from "./middleware.js";

--- a/packages/llm/src/prompts/delivery.ts
+++ b/packages/llm/src/prompts/delivery.ts
@@ -1,0 +1,82 @@
+export type DeliveryChannel = "email" | "slack";
+
+export interface DeliveryDigestInput {
+  subreddits: Array<{
+    name: string;
+    posts: Array<{
+      title: string;
+      score: number;
+      summary: string;
+      keyTakeaways: string[];
+      insightNotes: string;
+      commentHighlights: Array<{
+        author: string;
+        insight: string;
+        score: number;
+      }>;
+    }>;
+  }>;
+}
+
+const EMAIL_SYSTEM = `You are writing a brief newsletter-style digest of curated Reddit posts for a personal subscriber.
+
+Structure your output as JSON with:
+1. "headline" — A 2-3 sentence overview highlighting the most noteworthy findings across all subreddits. Write it as engaging prose that makes the reader want to keep reading.
+2. "sections" — One entry per subreddit. Each section's "body" is a 2-4 sentence paragraph covering that subreddit's posts. Mention post titles naturally within the prose. Highlight key findings, notable community reactions, and why they matter.
+
+Guidelines:
+- Write natural flowing prose. No bullet points, numbered lists, or section headers within the text.
+- Reference post titles when discussing specific findings so the reader knows which post is being discussed.
+- Be concise but substantive — every sentence should earn its place.
+- The reader is a developer — use appropriate technical vocabulary without over-explaining.`;
+
+const SLACK_SYSTEM = `You are writing an ultra-concise Reddit digest for Slack. Be brief, punchy, and direct.
+
+Structure your output as JSON with:
+1. "headline" — 1-2 sentences. The single most notable finding or trend across all subreddits.
+2. "sections" — One entry per subreddit. Each section's "body" is 1-2 sentences max — just the most important takeaway.
+
+Guidelines:
+- Extremely concise. Every word must earn its place.
+- No bullet points or formatting within the text. Plain prose only.
+- Total output should be scannable in under 30 seconds.
+- Mention post titles only when essential for context.`;
+
+export function buildDeliverySystemPrompt(channel: DeliveryChannel): string {
+  return channel === "email" ? EMAIL_SYSTEM : SLACK_SYSTEM;
+}
+
+export function buildDeliveryUserPrompt(input: DeliveryDigestInput): string {
+  const parts: string[] = ["Here are the curated posts grouped by subreddit:\n"];
+
+  for (const sub of input.subreddits) {
+    parts.push(`## r/${sub.name}`);
+
+    for (const post of sub.posts) {
+      parts.push(`### ${post.title} (${post.score} pts)`);
+      parts.push(post.summary);
+
+      if (post.keyTakeaways.length > 0) {
+        parts.push("Key takeaways:");
+        for (const t of post.keyTakeaways) {
+          parts.push(`- ${t}`);
+        }
+      }
+
+      if (post.insightNotes) {
+        parts.push(`Relevance: ${post.insightNotes}`);
+      }
+
+      if (post.commentHighlights.length > 0) {
+        parts.push("Notable comments:");
+        for (const c of post.commentHighlights) {
+          parts.push(`- u/${c.author} (${c.score} pts): ${c.insight}`);
+        }
+      }
+
+      parts.push("");
+    }
+  }
+
+  return parts.join("\n");
+}

--- a/packages/llm/src/prompts/index.ts
+++ b/packages/llm/src/prompts/index.ts
@@ -3,3 +3,5 @@ export type { TriagePostCandidate } from "./triage.js";
 export { buildSummarizationSystemPrompt, buildSummarizationUserPrompt } from "./summarization.js";
 export type { SummarizationPost, SummarizationComment } from "./summarization.js";
 export { sanitizeForPrompt } from "./sanitize.js";
+export { buildDeliverySystemPrompt, buildDeliveryUserPrompt } from "./delivery.js";
+export type { DeliveryDigestInput, DeliveryChannel } from "./delivery.js";

--- a/packages/llm/src/provider.ts
+++ b/packages/llm/src/provider.ts
@@ -12,6 +12,7 @@ export interface ModelConfig {
 const DEFAULT_MODELS: Record<string, ModelConfig> = {
   triage: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
   summarize: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
+  delivery: { provider: "anthropic", model: "claude-haiku-4-5-20251001" },
 };
 
 export function getModel(

--- a/packages/llm/src/schemas.ts
+++ b/packages/llm/src/schemas.ts
@@ -74,3 +74,27 @@ export const PostSummarySchema = z.object({
 });
 
 export type PostSummary = z.infer<typeof PostSummarySchema>;
+
+export const DeliveryProseSchema = z.object({
+  headline: z
+    .string()
+    .describe(
+      "Opening paragraph covering the most noteworthy findings across all subreddits. Engaging, flowing prose.",
+    ),
+  sections: z
+    .array(
+      z.object({
+        subreddit: z
+          .string()
+          .describe("Subreddit name without r/ prefix"),
+        body: z
+          .string()
+          .describe(
+            "Prose paragraph covering this subreddit's posts. Mention post titles naturally within the text.",
+          ),
+      }),
+    )
+    .describe("One section per subreddit, ordered as provided"),
+});
+
+export type DeliveryProse = z.infer<typeof DeliveryProseSchema>;

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -20,6 +20,7 @@
     "@redgest/core": "workspace:*",
     "@redgest/db": "workspace:*",
     "@redgest/email": "workspace:*",
+    "@redgest/llm": "workspace:*",
     "@redgest/reddit": "workspace:*",
     "@redgest/slack": "workspace:*",
     "@trigger.dev/sdk": "^4.4.3",

--- a/packages/mcp-server/src/__tests__/tools.test.ts
+++ b/packages/mcp-server/src/__tests__/tools.test.ts
@@ -5,14 +5,27 @@ import type { BootstrapResult } from "../bootstrap.js";
 import type { ToolResult } from "../envelope.js";
 import { createToolHandlers, createToolServer, type ToolHandler } from "../tools.js";
 
-// Mock email rendering (preview_digest uses renderDigestHtml)
+// Mock email rendering (preview_digest uses renderDigestHtml + buildFormattedDigest)
 vi.mock("@redgest/email", () => ({
   buildDeliveryData: vi.fn().mockReturnValue({
     digestId: "d1",
     createdAt: new Date("2026-03-10"),
     subreddits: [{ name: "test", posts: [{ title: "Post", permalink: "/r/test/1", score: 10, summary: "Sum", keyTakeaways: [], insightNotes: "", commentHighlights: [] }] }],
   }),
+  buildFormattedDigest: vi.fn().mockReturnValue({
+    createdAt: new Date("2026-03-10"),
+    headline: "Test headline.",
+    sections: [{ subreddit: "test", body: "Test body.", posts: [{ title: "Post", permalink: "/r/test/1", score: 10 }] }],
+  }),
   renderDigestHtml: vi.fn().mockResolvedValue("<html>preview</html>"),
+}));
+
+// Mock LLM (preview_digest uses generateDeliveryProse)
+vi.mock("@redgest/llm", () => ({
+  generateDeliveryProse: vi.fn().mockResolvedValue({
+    data: { headline: "Test headline.", sections: [{ subreddit: "test", body: "Test body." }] },
+    log: null,
+  }),
 }));
 
 // Mock slack formatting (preview_digest uses formatDigestBlocks)

--- a/packages/mcp-server/src/bootstrap.ts
+++ b/packages/mcp-server/src/bootstrap.ts
@@ -95,12 +95,28 @@ export async function bootstrap(): Promise<BootstrapResult> {
       },
     });
 
-    const { buildDeliveryData, sendDigestEmail } = await import(
+    const { buildDeliveryData, buildFormattedDigest, sendDigestEmail } = await import(
       "@redgest/email"
     );
     const { sendDigestSlack } = await import("@redgest/slack");
+    const { generateDeliveryProse } = await import("@redgest/llm");
 
     const deliveryData = buildDeliveryData(digest);
+
+    // Map to LLM input
+    const llmInput = {
+      subreddits: deliveryData.subreddits.map((s) => ({
+        name: s.name,
+        posts: s.posts.map((p) => ({
+          title: p.title,
+          score: p.score,
+          summary: p.summary,
+          keyTakeaways: p.keyTakeaways,
+          insightNotes: p.insightNotes,
+          commentHighlights: p.commentHighlights,
+        })),
+      })),
+    };
 
     // Determine which channels are configured
     const channels: Array<{
@@ -114,8 +130,11 @@ export async function bootstrap(): Promise<BootstrapResult> {
       channels.push({
         name: "email",
         type: "EMAIL",
-        send: () =>
-          sendDigestEmail(deliveryData, DELIVERY_EMAIL, RESEND_API_KEY),
+        send: async () => {
+          const { data: prose } = await generateDeliveryProse(llmInput, "email");
+          const formatted = buildFormattedDigest(deliveryData, prose);
+          return sendDigestEmail(formatted, DELIVERY_EMAIL, RESEND_API_KEY);
+        },
       });
     }
 
@@ -124,7 +143,11 @@ export async function bootstrap(): Promise<BootstrapResult> {
       channels.push({
         name: "slack",
         type: "SLACK",
-        send: () => sendDigestSlack(deliveryData, webhookUrl),
+        send: async () => {
+          const { data: prose } = await generateDeliveryProse(llmInput, "slack");
+          const formatted = buildFormattedDigest(deliveryData, prose);
+          return sendDigestSlack(formatted, webhookUrl);
+        },
       });
     }
 

--- a/packages/mcp-server/src/tools.ts
+++ b/packages/mcp-server/src/tools.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { ErrorCode, RedgestError, parseDuration, type ExecuteContext } from "@redgest/core";
 import type { DeliveryChannel } from "@redgest/db";
-import { buildDeliveryData, renderDigestHtml } from "@redgest/email";
+import { buildDeliveryData, buildFormattedDigest, renderDigestHtml } from "@redgest/email";
+import { generateDeliveryProse } from "@redgest/llm";
 import { formatDigestBlocks, type SlackBlock } from "@redgest/slack";
 import type { BootstrapResult } from "./bootstrap.js";
 import { envelope, envelopeError, type ToolResult } from "./envelope.js";
@@ -794,8 +795,25 @@ export function createToolHandlers(
 
         const deliveryData = buildDeliveryData(digest);
 
+        // Map to LLM input
+        const llmInput = {
+          subreddits: deliveryData.subreddits.map((s) => ({
+            name: s.name,
+            posts: s.posts.map((p) => ({
+              title: p.title,
+              score: p.score,
+              summary: p.summary,
+              keyTakeaways: p.keyTakeaways,
+              insightNotes: p.insightNotes,
+              commentHighlights: p.commentHighlights,
+            })),
+          })),
+        };
+
         if (channel === "email") {
-          const html = await renderDigestHtml(deliveryData);
+          const { data: prose } = await generateDeliveryProse(llmInput, "email");
+          const formatted = buildFormattedDigest(deliveryData, prose);
+          const html = await renderDigestHtml(formatted);
           return envelope({
             channel: "email",
             content: html,
@@ -806,7 +824,9 @@ export function createToolHandlers(
         }
 
         // Slack channel
-        const blocks: SlackBlock[] = formatDigestBlocks(deliveryData);
+        const { data: slackProse } = await generateDeliveryProse(llmInput, "slack");
+        const slackFormatted = buildFormattedDigest(deliveryData, slackProse);
+        const blocks: SlackBlock[] = formatDigestBlocks(slackFormatted);
         const SLACK_BLOCK_LIMIT = 50;
         const SLACK_TEXT_LIMIT = 3000;
         const truncationWarnings: string[] = [];

--- a/packages/slack/src/__tests__/format.test.ts
+++ b/packages/slack/src/__tests__/format.test.ts
@@ -1,25 +1,22 @@
 import { describe, it, expect } from "vitest";
-import type { DigestDeliveryData } from "@redgest/email";
+import type { FormattedDigest } from "@redgest/email";
 import { formatDigestBlocks } from "../format.js";
 
 function makeDigest(
-  overrides?: Partial<DigestDeliveryData>,
-): DigestDeliveryData {
+  overrides?: Partial<FormattedDigest>,
+): FormattedDigest {
   return {
-    digestId: "digest-001",
     createdAt: new Date("2026-03-10T12:00:00Z"),
-    subreddits: [
+    headline: "Test headline.",
+    sections: [
       {
-        name: "typescript",
+        subreddit: "typescript",
+        body: "Test body prose.",
         posts: [
           {
             title: "Test Post",
             permalink: "/r/typescript/comments/abc/test",
             score: 100,
-            summary: "A test post summary.",
-            keyTakeaways: ["takeaway one", "takeaway two"],
-            insightNotes: "notes",
-            commentHighlights: [],
           },
         ],
       },
@@ -41,8 +38,12 @@ describe("formatDigestBlocks", () => {
 
   it("produces divider and subreddit section blocks", () => {
     const blocks = formatDigestBlocks(makeDigest());
-    const divider = blocks[1];
-    const subSection = blocks[2];
+    const headline = blocks[1];
+    const divider = blocks[2];
+    const subSection = blocks[3];
+    expect(headline).toBeDefined();
+    expect(headline?.type).toBe("section");
+    expect(headline?.text?.text).toBe("Test headline.");
     expect(divider).toBeDefined();
     expect(divider?.type).toBe("divider");
     expect(subSection).toBeDefined();
@@ -51,128 +52,86 @@ describe("formatDigestBlocks", () => {
     expect(subSection?.text?.type).toBe("mrkdwn");
   });
 
-  it("formats post with mrkdwn link, score, and summary", () => {
+  it("formats body prose block and context block with post links", () => {
     const blocks = formatDigestBlocks(makeDigest());
-    const postBlock = blocks[3];
-    expect(postBlock).toBeDefined();
-    expect(postBlock?.type).toBe("section");
-    expect(postBlock?.text?.type).toBe("mrkdwn");
-    expect(postBlock?.text?.text).toContain(
-      "*<https://reddit.com/r/typescript/comments/abc/test|Test Post>*",
+    const bodyBlock = blocks[4];
+    expect(bodyBlock).toBeDefined();
+    expect(bodyBlock?.type).toBe("section");
+    expect(bodyBlock?.text?.type).toBe("mrkdwn");
+    expect(bodyBlock?.text?.text).toBe("Test body prose.");
+
+    const contextBlock = blocks[5];
+    expect(contextBlock).toBeDefined();
+    expect(contextBlock?.type).toBe("context");
+    expect(contextBlock?.elements).toBeDefined();
+    const linkText = contextBlock?.elements?.[0]?.text ?? "";
+    expect(linkText).toContain(
+      "<https://reddit.com/r/typescript/comments/abc/test|Test Post>",
     );
-    expect(postBlock?.text?.text).toContain("(100 pts)");
-    expect(postBlock?.text?.text).toContain("A test post summary.");
-  });
-
-  it("formats key takeaways as bullet list", () => {
-    const blocks = formatDigestBlocks(makeDigest());
-    const takeawayBlock = blocks[4];
-    expect(takeawayBlock).toBeDefined();
-    expect(takeawayBlock?.type).toBe("section");
-    expect(takeawayBlock?.text?.text).toContain("*Key Takeaways:*");
-    expect(takeawayBlock?.text?.text).toContain("\u2022 takeaway one");
-    expect(takeawayBlock?.text?.text).toContain("\u2022 takeaway two");
-  });
-
-  it("skips key takeaways block when array is empty", () => {
-    const digest = makeDigest({
-      subreddits: [
-        {
-          name: "typescript",
-          posts: [
-            {
-              title: "No Takeaways",
-              permalink: "/r/typescript/comments/xyz/no-takeaways",
-              score: 50,
-              summary: "No takeaways here.",
-              keyTakeaways: [],
-              insightNotes: "",
-              commentHighlights: [],
-            },
-          ],
-        },
-      ],
-    });
-    const blocks = formatDigestBlocks(digest);
-    // header, divider, sub section, post section — no takeaway block
-    expect(blocks).toHaveLength(4);
-    const types = blocks.map((b) => b.type);
-    expect(types).toEqual(["header", "divider", "section", "section"]);
+    expect(linkText).toContain("(100 pts)");
   });
 
   it("skips subreddits with no posts", () => {
     const digest = makeDigest({
-      subreddits: [
-        { name: "empty", posts: [] },
+      sections: [
+        { subreddit: "empty", body: "Nothing here.", posts: [] },
         {
-          name: "notempty",
+          subreddit: "notempty",
+          body: "Some content.",
           posts: [
             {
               title: "Post",
               permalink: "/r/notempty/comments/1/post",
               score: 10,
-              summary: "Summary.",
-              keyTakeaways: [],
-              insightNotes: "",
-              commentHighlights: [],
             },
           ],
         },
       ],
     });
     const blocks = formatDigestBlocks(digest);
-    // header, divider, sub section (notempty), post section — no "empty" sub
-    expect(blocks).toHaveLength(4);
-    const subBlock = blocks[2];
+    // header (1) + headline (1) + divider (1) + sub section (1) + body (1) + context (1) = 6
+    expect(blocks).toHaveLength(6);
+    const subBlock = blocks[3];
     expect(subBlock?.text?.text).toBe("*r/notempty*");
   });
 
   it("handles multiple subreddits with multiple posts", () => {
     const digest = makeDigest({
-      subreddits: [
+      sections: [
         {
-          name: "sub1",
+          subreddit: "sub1",
+          body: "Sub1 body.",
           posts: [
             {
               title: "P1",
               permalink: "/r/sub1/p1",
               score: 1,
-              summary: "s1",
-              keyTakeaways: ["t1"],
-              insightNotes: "",
-              commentHighlights: [],
             },
             {
               title: "P2",
               permalink: "/r/sub1/p2",
               score: 2,
-              summary: "s2",
-              keyTakeaways: [],
-              insightNotes: "",
-              commentHighlights: [],
             },
           ],
         },
         {
-          name: "sub2",
+          subreddit: "sub2",
+          body: "Sub2 body.",
           posts: [
             {
               title: "P3",
               permalink: "/r/sub2/p3",
               score: 3,
-              summary: "s3",
-              keyTakeaways: [],
-              insightNotes: "",
-              commentHighlights: [],
             },
           ],
         },
       ],
     });
     const blocks = formatDigestBlocks(digest);
-    // header
-    // divider, sub1 section, P1 section, P1 takeaways, P2 section
-    // divider, sub2 section, P3 section
-    expect(blocks).toHaveLength(9);
+    // header (1) + headline (1)
+    // sub1: divider (1) + sub section (1) + body (1) + context (1) = 4
+    // sub2: divider (1) + sub section (1) + body (1) + context (1) = 4
+    // total = 2 + 4 + 4 = 10
+    expect(blocks).toHaveLength(10);
   });
 });

--- a/packages/slack/src/__tests__/send.test.ts
+++ b/packages/slack/src/__tests__/send.test.ts
@@ -1,23 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { DigestDeliveryData } from "@redgest/email";
+import type { FormattedDigest } from "@redgest/email";
 import { sendDigestSlack } from "../send.js";
 
-function makeDigest(): DigestDeliveryData {
+function makeDigest(): FormattedDigest {
   return {
-    digestId: "digest-001",
     createdAt: new Date("2026-03-10T12:00:00Z"),
-    subreddits: [
+    headline: "Test headline.",
+    sections: [
       {
-        name: "typescript",
+        subreddit: "typescript",
+        body: "Test body prose.",
         posts: [
           {
             title: "Test Post",
             permalink: "/r/typescript/comments/abc/test",
             score: 100,
-            summary: "A test post summary.",
-            keyTakeaways: ["takeaway"],
-            insightNotes: "notes",
-            commentHighlights: [],
           },
         ],
       },

--- a/packages/slack/src/format.ts
+++ b/packages/slack/src/format.ts
@@ -1,4 +1,4 @@
-import type { DigestDeliveryData } from "@redgest/email";
+import type { FormattedDigest } from "@redgest/email";
 
 export interface SlackBlock {
   type: string;
@@ -6,7 +6,7 @@ export interface SlackBlock {
   elements?: Array<{ type: string; text: string }>;
 }
 
-export function formatDigestBlocks(digest: DigestDeliveryData): SlackBlock[] {
+export function formatDigestBlocks(digest: FormattedDigest): SlackBlock[] {
   const dateStr = digest.createdAt.toISOString().split("T")[0] ?? "";
   const blocks: SlackBlock[] = [
     {
@@ -17,33 +17,36 @@ export function formatDigestBlocks(digest: DigestDeliveryData): SlackBlock[] {
         emoji: true,
       },
     },
+    {
+      type: "section",
+      text: { type: "mrkdwn", text: digest.headline },
+    },
   ];
 
-  for (const sub of digest.subreddits) {
-    if (sub.posts.length === 0) continue;
+  for (const section of digest.sections) {
+    if (section.posts.length === 0) continue;
 
     blocks.push({ type: "divider" });
     blocks.push({
       type: "section",
-      text: { type: "mrkdwn", text: `*r/${sub.name}*` },
+      text: { type: "mrkdwn", text: `*r/${section.subreddit}*` },
+    });
+    blocks.push({
+      type: "section",
+      text: { type: "mrkdwn", text: section.body },
     });
 
-    for (const post of sub.posts) {
+    if (section.posts.length > 0) {
+      const links = section.posts
+        .map(
+          (p) =>
+            `<https://reddit.com${p.permalink}|${p.title}> (${p.score} pts)`,
+        )
+        .join("  ·  ");
       blocks.push({
-        type: "section",
-        text: {
-          type: "mrkdwn",
-          text: `*<https://reddit.com${post.permalink}|${post.title}>* (${post.score} pts)\n${post.summary}`,
-        },
+        type: "context",
+        elements: [{ type: "mrkdwn", text: links }],
       });
-
-      if (post.keyTakeaways.length > 0) {
-        const takeaways = post.keyTakeaways.map((t) => `\u2022 ${t}`).join("\n");
-        blocks.push({
-          type: "section",
-          text: { type: "mrkdwn", text: `*Key Takeaways:*\n${takeaways}` },
-        });
-      }
     }
   }
 

--- a/packages/slack/src/send.ts
+++ b/packages/slack/src/send.ts
@@ -1,8 +1,8 @@
-import type { DigestDeliveryData } from "@redgest/email";
+import type { FormattedDigest } from "@redgest/email";
 import { formatDigestBlocks } from "./format.js";
 
 export async function sendDigestSlack(
-  digest: DigestDeliveryData,
+  digest: FormattedDigest,
   webhookUrl: string,
 ): Promise<void> {
   const blocks = formatDigestBlocks(digest);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ importers:
       '@redgest/email':
         specifier: workspace:*
         version: link:../../packages/email
+      '@redgest/llm':
+        specifier: workspace:*
+        version: link:../../packages/llm
       '@redgest/reddit':
         specifier: workspace:*
         version: link:../../packages/reddit
@@ -294,6 +297,9 @@ importers:
       '@redgest/email':
         specifier: workspace:*
         version: link:../email
+      '@redgest/llm':
+        specifier: workspace:*
+        version: link:../llm
       '@redgest/reddit':
         specifier: workspace:*
         version: link:../reddit
@@ -5521,7 +5527,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1(supports-color@10.2.2)
-      express-rate-limit: 8.3.1(express@5.2.1)
+      express-rate-limit: 8.3.1(express@5.2.1(supports-color@10.2.2))
       hono: 4.12.5
       jose: 6.2.1
       json-schema-typed: 8.0.2
@@ -5543,7 +5549,7 @@ snapshots:
       eventsource: 3.0.7
       eventsource-parser: 3.0.6
       express: 5.2.1(supports-color@10.2.2)
-      express-rate-limit: 8.3.1(express@5.2.1)
+      express-rate-limit: 8.3.1(express@5.2.1(supports-color@10.2.2))
       hono: 4.12.5
       jose: 6.2.1
       json-schema-typed: 8.0.2
@@ -7774,7 +7780,7 @@ snapshots:
 
   expect-type@1.3.0: {}
 
-  express-rate-limit@8.3.1(express@5.2.1):
+  express-rate-limit@8.3.1(express@5.2.1(supports-color@10.2.2)):
     dependencies:
       express: 5.2.1(supports-color@10.2.2)
       ip-address: 10.1.0

--- a/scripts/test-delivery.ts
+++ b/scripts/test-delivery.ts
@@ -1,8 +1,9 @@
 import { config } from "dotenv";
 config({ override: true });
 import { prisma } from "@redgest/db";
-import { sendDigestEmail, buildDeliveryData } from "@redgest/email";
+import { sendDigestEmail, buildDeliveryData, buildFormattedDigest } from "@redgest/email";
 import { sendDigestSlack } from "@redgest/slack";
+import { generateDeliveryProse } from "@redgest/llm";
 
 const digestId = process.argv[2];
 if (!digestId) {
@@ -26,10 +27,27 @@ const digest = await prisma.digest.findUniqueOrThrow({
 
 const data = buildDeliveryData(digest);
 
+// Map to LLM input
+const llmInput = {
+  subreddits: data.subreddits.map((s) => ({
+    name: s.name,
+    posts: s.posts.map((p) => ({
+      title: p.title,
+      score: p.score,
+      summary: p.summary,
+      keyTakeaways: p.keyTakeaways,
+      insightNotes: p.insightNotes,
+      commentHighlights: p.commentHighlights,
+    })),
+  })),
+};
+
 // Send email
 try {
+  const { data: emailProse } = await generateDeliveryProse(llmInput, "email");
+  const emailFormatted = buildFormattedDigest(data, emailProse);
   const emailResult = await sendDigestEmail(
-    data,
+    emailFormatted,
     process.env.DELIVERY_EMAIL!,
     process.env.RESEND_API_KEY!,
   );
@@ -40,8 +58,10 @@ try {
 
 // Send Slack
 try {
+  const { data: slackProse } = await generateDeliveryProse(llmInput, "slack");
+  const slackFormatted = buildFormattedDigest(data, slackProse);
   const slackResult = await sendDigestSlack(
-    data,
+    slackFormatted,
     process.env.SLACK_WEBHOOK_URL!,
   );
   console.log("Slack sent:", JSON.stringify(slackResult));

--- a/tests/fixtures/fake-llm.ts
+++ b/tests/fixtures/fake-llm.ts
@@ -4,6 +4,9 @@ import type {
   PostSummary,
   SummarizationPost,
   SummarizationComment,
+  DeliveryProse,
+  DeliveryDigestInput,
+  DeliveryChannel,
 } from "@redgest/llm";
 import type { LanguageModel } from "ai";
 
@@ -55,6 +58,26 @@ export async function fakeGeneratePostSummary(
       relevanceScore: 7,
       contentType: "text",
       notableLinks: [],
+    },
+    log: null,
+  };
+}
+
+/**
+ * Fake delivery prose: returns deterministic prose based on input subreddits.
+ */
+export async function fakeGenerateDeliveryProse(
+  input: DeliveryDigestInput,
+  _channel: DeliveryChannel,
+  _model?: LanguageModel,
+): Promise<{ data: DeliveryProse; log: null }> {
+  return {
+    data: {
+      headline: `This digest covers ${input.subreddits.length} subreddit${input.subreddits.length === 1 ? "" : "s"} with the latest curated posts.`,
+      sections: input.subreddits.map((sub) => ({
+        subreddit: sub.name,
+        body: `r/${sub.name} featured ${sub.posts.length} post${sub.posts.length === 1 ? "" : "s"}${sub.posts.length > 0 ? `, including "${sub.posts[0]?.title}"` : ""}.`,
+      })),
     },
     log: null,
   };


### PR DESCRIPTION
## Summary
Introduces LLM-powered prose generation for digest delivery to email and Slack channels. The system generates natural, channel-specific prose (headlines and body text) that wraps curated post data, replacing the previous template-based approach with AI-generated content.

## Key Changes

- **New LLM delivery prompt module** (`packages/llm/src/prompts/delivery.ts`):
  - `buildDeliverySystemPrompt()` generates channel-specific instructions (email vs. Slack)
  - `buildDeliveryUserPrompt()` formats curated post data for the LLM
  - Email prompts emphasize newsletter structure and flowing prose
  - Slack prompts emphasize ultra-concise, scannable content

- **New prose generation function** (`packages/llm/src/generate-delivery-prose.ts`):
  - `generateDeliveryProse()` orchestrates LLM calls with caching and logging
  - Supports custom model overrides
  - Returns structured `DeliveryProse` with headline and per-subreddit body sections

- **New schema** (`packages/llm/src/schemas.ts`):
  - `DeliveryProseSchema` validates LLM output structure (headline + sections)

- **Refactored digest formatting** (`packages/email/src/types.ts`):
  - New `FormattedDigest` type replaces `DigestDeliveryData` in templates
  - Contains LLM-generated prose (headline, body) alongside post links
  - `buildFormattedDigest()` merges delivery data with generated prose

- **Updated email/Slack templates**:
  - Email template now renders headline and prose body instead of individual post summaries
  - Slack formatter includes headline block and prose body per subreddit
  - Post links appear as context/reference rather than primary content

- **Integration points**:
  - Worker task, MCP server, and test delivery script updated to call `generateDeliveryProse()`
  - LLM input mapped from `DigestDeliveryData` (drops fields not needed by LLM)
  - Cache TTL configured for delivery tasks (7 days)

- **Comprehensive test coverage**:
  - Prompt building tests verify channel-specific instructions and content inclusion
  - Prose generation tests mock LLM calls and verify caching/logging
  - Schema validation tests ensure output structure
  - Template tests updated to verify prose rendering

## Implementation Details

- Prose generation is cached per channel to avoid redundant LLM calls
- Channel-specific system prompts guide tone and structure (newsletter vs. Slack brevity)
- Post data is formatted as structured markdown in user prompts for clarity
- Generated prose is merged with original post metadata to preserve links and scores
- All existing digest delivery infrastructure reused; only the formatting layer changed

https://claude.ai/code/session_01X5qMEqS48NzYaD9d4dSQMx